### PR TITLE
노트 생성 요청에 대한 응답 형식 업데이트

### DIFF
--- a/backend/src/controllers/notes.controller.ts
+++ b/backend/src/controllers/notes.controller.ts
@@ -22,9 +22,9 @@ const createNote = async (req: Request, res: Response, next: NextFunction) => {
     const userId = req.user!.id;
     const { title, content } = req.body;
 
-    await NotesService.createNote(title, content, userId);
+    const noteId = await NotesService.createNote(title, content, userId);
 
-    res.sendStatus(StatusCodes.CREATED);
+    res.status(StatusCodes.CREATED).json({ id: noteId });
 };
 
 const updateNote = async (req: Request, res: Response, next: NextFunction) => {

--- a/backend/src/services/notes.service.ts
+++ b/backend/src/services/notes.service.ts
@@ -19,7 +19,9 @@ const getNote = async (noteId: number): Promise<Note> => {
 const createNote = async (title: string, content: string, userId: number) => {
     const result = await NotesRepository.create(title, content, userId);
 
-    if (result.affectedRows !== 1) throw new CreateNoteFail();
+    if (result.affectedRows === 1) return result.insertId;
+
+    throw new CreateNoteFail();
 };
 
 const updateNote = async (noteId: number, title: string, content: string) => {


### PR DESCRIPTION
- frontend에서 note 생성 후 해당 note의 detail 페이지로 이동시키기 위해 createNote 요청 시 새롭게 생성된 노트의 id, 즉 insertId를 반환하도록 수정
- frontend에서는 요청이 성공하면 이 id를 이용해 새롭게 생성된 note의 detail 페이지 `/notes/:id`로 이동